### PR TITLE
STRY0019104 - Test against GSP version of Nextflow in GitHub CI for all pipelines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
       matrix:
         NXF_VER:
           - "23.04.0"
+          - "24.10.3"
           - "latest-everything"
     steps:
       - name: Check out pipeline code
@@ -170,6 +171,7 @@ jobs:
           sudo mv nf-test /usr/local/bin/
 
       - name: Run nf-test
+        continue-on-error: ${{ matrix.NXF_VER == 'latest-everything' }}
         run: |
           nf-test test
 
@@ -179,5 +181,6 @@ jobs:
           SUBMITDATAIRIDANEXT_SRA_UPLOAD_PASSWORD: "ftppass"
           SUBMITDATAIRIDANEXT_ENA_UPLOAD_USERNAME: "test_ena_user"
           SUBMITDATAIRIDANEXT_ENA_UPLOAD_PASSWORD: "test_ena_password"
+        continue-on-error: ${{ matrix.NXF_VER == 'latest-everything' }}
         run: |
           nextflow run ${GITHUB_WORKSPACE} -profile test,singularity --sra_ftp_server localhost --sra_user_account_dirname "ftpuser" --test_upload --outdir ./results


### PR DESCRIPTION
Adding GitHub CI tests against Nextflow `24.10.3`

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] `CHANGELOG.md` is updated.